### PR TITLE
Update Config to Match Latest Upstream

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,26 +1,29 @@
 ---
 # defaults file for Uccio.automysqlbackup
-#automysqlbackup_source:  https://sourceforge.net/projects/automysqlbackup/files/latest/download
+#automysqlbackup_source: https://sourceforge.net/projects/automysqlbackup/files/latest/download
 automysqlbackup_source: https://github.com/sixhop/AutoMySQLBackup/archive/master.zip
 automysqlbackup_tmp_file: '/tmp/automysqlbackup/AutoMySQLBackup-master/automysqlbackup'
 
 
-automysqlbackup_mysql_dump_username: ''
+automysqlbackup_mysql_dump_username: 'root'
 automysqlbackup_mysql_dump_password: ''
-automysqlbackup_mysql_dump_login_path: 'automysqlbackup'
+automysqlbackup_mysql_dump_login_path: 'automysqldump'
+automysqlbackup_mysql_dump_login_path_file: ''
+automysqlbackup_mysql_dump_encrypted_login: 'no'
 
 
 automysqlbackup_mysql_dump_host: 'localhost'
-automysqlbackup_mysql_dump_host_friendly: 'localhost'
+automysqlbackup_mysql_dump_host_friendly: ''
 automysqlbackup_backup_dir: '/var/backups/db'
-automysqlbackup_multicore: 'no'
+automysqlbackup_multicore: 'yes'
 automysqlbackup_multicore_threads: 2
 automysqlbackup_db_names: ''
 automysqlbackup_db_month_names: ''
-automysqlbackup_db_exclude: "'information_schema' 'mysql' 'performance_schema' 'test' 'sys'"
+automysqlbackup_db_exclude: "'performance_schema' 'information_schema'"
+automysqlbackup_db_exclude_pattern: ''
 automysqlbackup_table_exclude: ''
-automysqlbackup_do_monthly: "01"
-automysqlbackup_do_weekly: 5
+automysqlbackup_do_monthly: '01'
+automysqlbackup_do_weekly: '5'
 automysqlbackup_rotation_daily: 6
 automysqlbackup_rotation_weekly: 35
 automysqlbackup_rotation_monthly: 150
@@ -30,9 +33,11 @@ automysqlbackup_mysql_dump_usessl: 'no'
 automysqlbackup_mysql_dump_socket: ''
 automysqlbackup_mysql_dump_max_allowed_packet: ''
 automysqlbackup_mysql_dump_single_transaction: 'no'
-automysqlbackup_mysql_dump_full_schema: 'no'
-automysqlbackup_mysql_dump_dbstatus: 'no'
-automysqlbackup_mysql_dump_create_database: 'yes'
+automysqlbackup_mysql_dump_master_data: ~
+automysqlbackup_mysql_dump_full_schema: 'yes'
+automysqlbackup_mysql_dump_dbstatus: 'yes'
+automysqlbackup_mysql_dump_create_database: 'no'
+automysqlbackup_mysql_dump_add_drop_database: 'no'
 automysqlbackup_mysql_dump_use_separate_dirs: 'yes'
 automysqlbackup_mysql_dump_compression: 'gzip'
 automysqlbackup_mysql_dump_latest: 'no'
@@ -45,6 +50,5 @@ automysqlbackup_mail_use_uuencoded_attachments: 'no'
 automysqlbackup_mail_address: 'root'
 automysqlbackup_encrypt: 'no'
 automysqlbackup_encrypt_password: 'password0123'
-automysqlbackup_backup_local_files:  ''
-automysqlbackup_prebackup: ''
+automysqlbackup_backup_local_files: ''
 automysqlbackup_dryrun: 0

--- a/templates/automysqlbackup.conf
+++ b/templates/automysqlbackup.conf
@@ -14,16 +14,30 @@
 
 # Basic Settings
 
+# use encrypted authentication credentials
+# yes: through login path
+# no: through username and password
+CONFIG_mysql_dump_encrypted_login='{{ automysqlbackup_mysql_dump_encrypted_login }}'
+
+# since mysql 5.6.x connections can be stored securely
+# add your connection with
+# mysql_config_editor set --login-path=automysqldump --host=localhost --user=root --password
+# automysqldump is using the login-path "automysqldump" as default
+CONFIG_mysql_dump_login_path='{{ automysqlbackup_mysql_dump_login_path }}'
+
+# Path to the mysql login configuration file.
+# Sometimes if the script is running in a cronjob, the mysql login configuration file cannot be located.
+# I.e. set it to '/root/.mylogin.cnf' or '/home/username/.mylogin.cnf'
+CONFIG_mysql_dump_login_path_file='{{ automysqlbackup_mysql_dump_login_path_file }}'
+
 # Username to access the MySQL server e.g. dbuser
 CONFIG_mysql_dump_username='{{ automysqlbackup_mysql_dump_username }}'
 
 # Password to access the MySQL server e.g. password
 CONFIG_mysql_dump_password='{{ automysqlbackup_mysql_dump_password }}'
 
-CONFIG_mysql_dump_encrypted_login='yes'
-
 # Host name (or IP address) of MySQL server e.g localhost
-CONFIG_mysql_dump_host='{{automysqlbackup_mysql_dump_host}}'
+CONFIG_mysql_dump_host='{{ automysqlbackup_mysql_dump_host }}'
 
 # "Friendly" host name of MySQL server to be used in email log
 # if unset or empty (default) will use CONFIG_mysql_dump_host instead
@@ -38,6 +52,7 @@ CONFIG_backup_dir='{{ automysqlbackup_backup_dir }}'
 # to use them, just choose no here.
 # pigz -> gzip
 # pbzip2 -> bzip2
+# xz -T -> xz
 CONFIG_multicore='{{ automysqlbackup_multicore }}'
 
 # Number of threads (= occupied cores) you want to use. You should - for the sake
@@ -63,13 +78,16 @@ CONFIG_db_names=({{ automysqlbackup_db_names }})
 CONFIG_db_month_names=({{ automysqlbackup_db_month_names }})
 
 # List of DBNAMES to EXLUCDE if DBNAMES is empty, i.e. ().
-CONFIG_db_exclude=({{  automysqlbackup_db_exclude }})
+CONFIG_db_exclude=({{ automysqlbackup_db_exclude }})
+
+# List of DBNAMES patterns to EXLUCDE if DBNAMES is empty, i.e. ().
+CONFIG_db_exclude_pattern=({{ automysqlbackup_db_exclude_pattern }})
 
 # List of tables to exclude, in the form db_name.table_name
 # You may use wildcards for the table names, i.e. 'mydb.a*' selects all tables starting with an 'a'.
 # However we only offer the wildcard '*', matching everything that could appear, which translates to the
 # '%' wildcard in mysql.
-CONFIG_table_exclude=( {{ automysqlbackup_table_exclude }})
+CONFIG_table_exclude=({{ automysqlbackup_table_exclude }})
 
 
 # Advanced Settings
@@ -80,39 +98,39 @@ CONFIG_table_exclude=( {{ automysqlbackup_table_exclude }})
 # If the chosen day is greater than the last day of the month, it will be done
 # on the last day of the month.
 # Set to 0 to disable monthly backups.
-#CONFIG_do_monthly="01"
+CONFIG_do_monthly='{{ automysqlbackup_do_monthly }}'
 
 # Which day do you want weekly backups? (1 to 7 where 1 is Monday)
 # Set to 0 to disable weekly backups.
-#CONFIG_do_weekly="5"
+CONFIG_do_weekly='{{ automysqlbackup_do_weekly }}'
 
 # Set rotation of daily backups. VALUE*24hours
 # If you want to keep only today's backups, you could choose 1, i.e. everything older than 24hours will be removed.
-#CONFIG_rotation_daily=6
+CONFIG_rotation_daily={{ automysqlbackup_rotation_daily }}
 
 # Set rotation for weekly backups. VALUE*24hours
-#CONFIG_rotation_weekly=35
+CONFIG_rotation_weekly={{ automysqlbackup_rotation_weekly }}
 
 # Set rotation for monthly backups. VALUE*24hours
-#CONFIG_rotation_monthly=150
+CONFIG_rotation_monthly={{ automysqlbackup_rotation_monthly }}
 
 
 # Server Connection Settings
 
 # Set the port for the mysql connection
-#CONFIG_mysql_dump_port=3306
+CONFIG_mysql_dump_port={{ automysqlbackup_mysql_dump_port }}
 
 # Compress communications between backup server and MySQL server?
-#CONFIG_mysql_dump_commcomp='no'
+CONFIG_mysql_dump_commcomp='{{ automysqlbackup_mysql_dump_commcomp }}'
 
 # Use ssl encryption with mysqldump?
 CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 
 # For connections to localhost. Sometimes the Unix socket file must be specified.
-#CONFIG_mysql_dump_socket=''
+CONFIG_mysql_dump_socket='{{ automysqlbackup_mysql_dump_socket }}'
 
 # The maximum size of the buffer for client/server communication. e.g. 16MB (maximum is 1GB)
-#CONFIG_mysql_dump_max_allowed_packet=''
+CONFIG_mysql_dump_max_allowed_packet='{{ automysqlbackup_mysql_dump_max_allowed_packet }}'
 
 # This option sends a START TRANSACTION SQL statement to the server before dumping data. It is useful only with
 # transactional tables such as InnoDB, because then it dumps the consistent state of the database at the time
@@ -126,10 +144,10 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 # DROP TABLE, RENAME TABLE, TRUNCATE TABLE. A consistent read is not isolated from those statements, so use of
 # them on a table to be dumped can cause the SELECT that is performed by mysqldump to retrieve the table
 # contents to obtain incorrect contents or fail.
-#CONFIG_mysql_dump_single_transaction='no'
+CONFIG_mysql_dump_single_transaction='{{ automysqlbackup_mysql_dump_single_transaction }}'
 
 # http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html#option_mysqldump_master-data
-# --master-data[=value] 
+# --master-data[=value]
 # Use this option to dump a master replication server to produce a dump file that can be used to set up another
 # server as a slave of the master. It causes the dump output to include a CHANGE MASTER TO statement that indicates
 # the binary log coordinates (file name and position) of the dumped server. These are the master server coordinates
@@ -139,7 +157,7 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 # it has no effect when the dump file is reloaded. If the option value is 1, the statement is not written as a comment
 # and takes effect when the dump file is reloaded. If no option value is specified, the default value is 1.
 #
-# This option requires the RELOAD privilege and the binary log must be enabled. 
+# This option requires the RELOAD privilege and the binary log must be enabled.
 #
 # The --master-data option automatically turns off --lock-tables. It also turns on --lock-all-tables, unless
 # --single-transaction also is specified, in which case, a global read lock is acquired only for a short time at the
@@ -149,7 +167,7 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 # possible values are 1 and 2, which correspond with the values from mysqldump
 # VARIABLE=    , i.e. no value, turns it off (default)
 #
-#CONFIG_mysql_dump_master_data=
+CONFIG_mysql_dump_master_data={{ automysqlbackup_mysql_dump_master_data }}
 
 # Included stored routines (procedures and functions) for the dumped databases in the output. Use of this option
 # requires the SELECT privilege for the mysql.proc table. The output generated by using --routines contains
@@ -159,38 +177,41 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 #
 # If you require routines to be re-created with their original timestamp attributes, do not use --routines. Instead,
 # dump and reload the contents of the mysql.proc table directly, using a MySQL account that has appropriate privileges
-# for the mysql database. 
+# for the mysql database.
 #
 # This option was added in MySQL 5.0.13. Before that, stored routines are not dumped. Routine DEFINER values are not
 # dumped until MySQL 5.0.20. This means that before 5.0.20, when routines are reloaded, they will be created with the
 # definer set to the reloading user. If you require routines to be re-created with their original definer, dump and
 # load the contents of the mysql.proc table directly as described earlier.
 #
-#CONFIG_mysql_dump_full_schema='yes'
+CONFIG_mysql_dump_full_schema='{{ automysqlbackup_mysql_dump_full_schema }}'
 
 # Backup status of table(s) in textfile. This is very helpful when restoring backups, since it gives an idea, what changed
 # in the meantime.
-#CONFIG_mysql_dump_dbstatus='yes'
+CONFIG_mysql_dump_dbstatus='{{ automysqlbackup_mysql_dump_dbstatus }}'
 
 # Backup dump settings
 
 # Include CREATE DATABASE in backup?
-#CONFIG_mysql_dump_create_database='no'
+CONFIG_mysql_dump_create_database='{{ automysqlbackup_mysql_dump_create_database }}'
+
+# Include DROP DATABASE in backup?
+CONFIG_mysql_dump_add_drop_database='{{ automysqlbackup_mysql_dump_add_drop_database }}'
 
 # Separate backup directory and file for each DB? (yes or no)
-#CONFIG_mysql_dump_use_separate_dirs='yes'
+CONFIG_mysql_dump_use_separate_dirs='{{ automysqlbackup_mysql_dump_use_separate_dirs }}'
 
-# Choose Compression type. (gzip or bzip2)
-#CONFIG_mysql_dump_compression='gzip'
+# Choose Compression type. (gzip, bzip2 or xz)
+CONFIG_mysql_dump_compression='{{ automysqlbackup_mysql_dump_compression }}'
 
 # Store an additional copy of the latest backup to a standard
 # location so it can be downloaded by third party scripts.
-#CONFIG_mysql_dump_latest='no'
+CONFIG_mysql_dump_latest='{{ automysqlbackup_mysql_dump_latest }}'
 
 # Remove all date and time information from the filenames in the latest folder.
 # Runs, if activated, once after the backups are completed. Practically it just finds all files in the latest folder
 # and removes the date and time information from the filenames (if present).
-#CONFIG_mysql_dump_latest_clean_filenames='no'
+CONFIG_mysql_dump_latest_clean_filenames='{{ automysqlbackup_mysql_dump_latest_clean_filenames }}'
 
 # Create differential backups. Master backups are created weekly at #$CONFIG_do_weekly weekday. Between master backups,
 # diff is used to create differential backups relative to the latest master backup. In the Manifest file, you find the
@@ -204,7 +225,7 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 #
 # To ensure that master backups are kept long enough, the value of $CONFIG_rotation_daily is set to a minimum of 21 days.
 #
-#CONFIG_mysql_dump_differential='no'
+CONFIG_mysql_dump_differential='{{ automysqlbackup_mysql_dump_differential }}'
 
 
 # Notification setup
@@ -214,28 +235,28 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 # - files : send log file and sql files as attachments (see docs)
 # - stdout : will simply output the log to the screen if run manually.
 # - quiet : Only send logs if an error occurs to the MAILADDR.
-#CONFIG_mailcontent='stdout'
+CONFIG_mailcontent='{{ automysqlbackup_mailcontent }}'
 
 # Set the maximum allowed email size in k. (4000 = approx 5MB email [see docs])
-#CONFIG_mail_maxattsize=4000
+CONFIG_mail_maxattsize={{ automysqlbackup_mail_maxattsize }}
 
 # Allow packing of files with tar and splitting it in pieces of CONFIG_mail_maxattsize.
-#CONFIG_mail_splitandtar='yes'
+CONFIG_mail_splitandtar='{{ automysqlbackup_mail_splitandtar }}'
 
 # Use uuencode instead of mutt. WARNING: Not all email clients work well with uuencoded attachments.
-#CONFIG_mail_use_uuencoded_attachments='no'
+CONFIG_mail_use_uuencoded_attachments='{{ automysqlbackup_mail_use_uuencoded_attachments }}'
 
 # Email Address to send mail to? (user@domain.com)
-#CONFIG_mail_address='root'
+CONFIG_mail_address='{{ automysqlbackup_mail_address }}'
 
 
 # Encryption
 
 # Do you wish to encrypt your backups using openssl?
-#CONFIG_encrypt='no'
+CONFIG_encrypt='{{ automysqlbackup_encrypt }}'
 
 # Choose a password to encrypt the backups.
-#CONFIG_encrypt_password='password0123'
+CONFIG_encrypt_password='{{ automysqlbackup_encrypt_password }}'
 
 # Other
 
@@ -244,13 +265,21 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 # depending on the option CONFIG_encrypt encrypted.
 #
 # Note: This could also have been accomplished with CONFIG_prebackup or CONFIG_postbackup.
-#CONFIG_backup_local_files=()
+CONFIG_backup_local_files=({{ automysqlbackup_backup_local_files }})
 
 # Command to run before backups (uncomment to use)
-#CONFIG_prebackup="/etc/mysql-backup-pre"
+{% if automysqlbackup_prebackup is defined %}
+CONFIG_prebackup='{{ automysqlbackup_prebackup }}'
+{% else %}
+#CONFIG_prebackup='/etc/mysql-backup-pre'
+{% endif %}
 
 # Command run after backups (uncomment to use)
-#CONFIG_postbackup="/etc/mysql-backup-post"
+{% if automysqlbackup_postbackup is defined %}
+CONFIG_postbackup='{{ automysqlbackup_postbackup }}'
+{% else %}
+#CONFIG_postbackup='/etc/mysql-backup-post'
+{% endif %}
 
 # Uncomment to activate! This will give folders rwx------
 # and files rw------- permissions.
@@ -259,6 +288,4 @@ CONFIG_mysql_dump_usessl='{{ automysqlbackup_mysql_dump_usessl }}'
 # dry-run, i.e. show what you are gonna do without actually doing it
 # inactive: =0 or commented out
 # active: uncommented AND =1
-#CONFIG_dryrun=1
-
-
+CONFIG_dryrun={{ automysqlbackup_dryrun }}


### PR DESCRIPTION
Make sure all config options match [upstream](https://github.com/sixhop/AutoMySQLBackup/blob/master/automysqlbackup.conf) defaults and are settable.